### PR TITLE
update Account directory to be consistent with OpenZeppelin v0.1.0

### DIFF
--- a/contracts/account/Account.cairo
+++ b/contracts/account/Account.cairo
@@ -13,8 +13,9 @@ from contracts.account.library import Account, AccountCallArray
 
 @constructor
 func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        public_key : felt):
-    Account.constructor(public_key)
+    public_key : felt
+):
+    Account.initializer(public_key)
     return ()
 end
 
@@ -24,7 +25,8 @@ end
 
 @view
 func get_public_key{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
-        res : felt):
+    res : felt
+):
     let (res) = Account.get_public_key()
     return (res=res)
 end
@@ -41,7 +43,8 @@ end
 
 @external
 func set_public_key{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        new_public_key : felt):
+    new_public_key : felt
+):
     Account.set_public_key(new_public_key)
     return ()
 end
@@ -52,19 +55,24 @@ end
 
 @view
 func is_valid_signature{
-        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        ecdsa_ptr : SignatureBuiltin*}(hash : felt, signature_len : felt, signature : felt*) -> ():
-    Account.is_valid_signature(hash, signature_len, signature)
-    return ()
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, ecdsa_ptr : SignatureBuiltin*
+}(hash : felt, signature_len : felt, signature : felt*) -> (is_valid : felt):
+    let (is_valid) = Account.is_valid_signature(hash, signature_len, signature)
+    return (is_valid=is_valid)
 end
 
 @external
 func __execute__{
-        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr,
-        ecdsa_ptr : SignatureBuiltin*}(
-        call_array_len : felt, call_array : AccountCallArray*, calldata_len : felt,
-        calldata : felt*, nonce : felt) -> (response_len : felt, response : felt*):
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, ecdsa_ptr : SignatureBuiltin*
+}(
+    call_array_len : felt,
+    call_array : AccountCallArray*,
+    calldata_len : felt,
+    calldata : felt*,
+    nonce : felt,
+) -> (response_len : felt, response : felt*):
     let (response_len, response) = Account.execute(
-        call_array_len, call_array, calldata_len, calldata, nonce)
+        call_array_len, call_array, calldata_len, calldata, nonce
+    )
     return (response_len=response_len, response=response)
 end

--- a/contracts/account/IAccount.cairo
+++ b/contracts/account/IAccount.cairo
@@ -3,7 +3,7 @@
 
 %lang starknet
 
-from openzeppelin.account.library import AccountCallArray
+from contracts.account.library import AccountCallArray
 
 @contract_interface
 namespace IAccount:
@@ -18,11 +18,17 @@ namespace IAccount:
     # Business logic
     #
 
-    func is_valid_signature(hash : felt, signature_len : felt, signature : felt*):
+    func is_valid_signature(hash : felt, signature_len : felt, signature : felt*) -> (
+        is_valid : felt
+    ):
     end
 
     func __execute__(
-            call_array_len : felt, call_array : AccountCallArray*, calldata_len : felt,
-            calldata : felt*, nonce : felt) -> (response_len : felt, response : felt*):
+        call_array_len : felt,
+        call_array : AccountCallArray*,
+        calldata_len : felt,
+        calldata : felt*,
+        nonce : felt,
+    ) -> (response_len : felt, response : felt*):
     end
 end


### PR DESCRIPTION
Resolved a signature validation issue with the Account contract/library by copying and pasting the OpenZeppelin patched code. Solution is on the ```__execute__``` function to assert that the caller address is the null address (ie the contract call must be initiated by an off-chain signer, not by another contract).

Original Issue:https://github.com/OpenZeppelin/cairo-contracts/issues/344

Patch: https://github.com/OpenZeppelin/cairo-contracts/pull/347/files

This was possible because Cairo's account structure does not natively distinguish between contracts and EOAs, so signature validation is done on a per-contract basis. A malicious tx could be approved for one function call, and then reenter in the same tx to call other functions after the signature validation. For more understanding of Account, read: https://github.com/OpenZeppelin/cairo-contracts/blob/main/docs/Account.md