### PR TITLE
Docker install pontis from pypi

### DIFF
--- a/.github/workflows/push_pontis_publisher.yaml
+++ b/.github/workflows/push_pontis_publisher.yaml
@@ -23,6 +23,6 @@ jobs:
         run: |
           export $(grep -v '^#' .env | xargs)
           export PONTIS_PACKAGE_VERSION=$(grep 'version' pontis-package/setup.cfg | grep -e '[0-9]\.[0-9]\.[0-9]' -o)
-          docker build . -t 42labs/pontis-publisher:${PONTIS_PACKAGE_VERSION}
+          docker build . --build-arg PONTIS_PACKAGE_VERSION=${PONTIS_PACKAGE_VERSION} -t 42labs/pontis-publisher:${PONTIS_PACKAGE_VERSION}
           docker login -u ${DOCKER_LOGIN} -p ${DOCKER_ACCESS_TOKEN}
           docker push 42labs/pontis-publisher:${PONTIS_PACKAGE_VERSION}

--- a/.github/workflows/update_prices.yaml
+++ b/.github/workflows/update_prices.yaml
@@ -16,7 +16,8 @@ jobs:
 
       - name: Build publisher images locally
         run: |
-          docker build . -t 42labs/pontis-publisher:latest
+          export PONTIS_PACKAGE_VERSION=$(grep 'version' pontis-package/setup.cfg | grep -e '[0-9]\.[0-9]\.[0-9]' -o)
+          docker build . --build-arg PONTIS_PACKAGE_VERSION=${PONTIS_PACKAGE_VERSION} -t 42labs/pontis-publisher:latest
           docker build publisher-utils/sample-publisher/all/ -t publish-all --build-arg PONTIS_PUBLISHER_BASE_IMAGE_TAG=latest
 
       - name: Post updated prices

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt --upgrade --upgrade-strategy eager
 
 ARG PONTIS_PACKAGE_VERSION
-RUN pip install pontis-package==$PONTIS_PACKAGE_VERSION
+RUN pip install pontis==$PONTIS_PACKAGE_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ RUN apt-get update && apt-get install -y gcc python-dev libgmp3-dev
 COPY requirements.txt /requirements.txt
 RUN pip install -r requirements.txt --upgrade --upgrade-strategy eager
 
-COPY pontis-package /pontis-package
-RUN pip install -e pontis-package
+ARG PONTIS_PACKAGE_VERSION
+RUN pip install pontis-package==$PONTIS_PACKAGE_VERSION


### PR DESCRIPTION
Before we installed Pontis in editable mode and from the local folder. In production, we want to install in regular mode and from PyPI to make sure we have the released version, not some local changes.