### PR TITLE
Amarna unused args fixes

### DIFF
--- a/contracts/account/library.cairo
+++ b/contracts/account/library.cairo
@@ -128,6 +128,7 @@ namespace Account:
         with_attr error_message("Account: nonce is invalid"):
             assert _current_nonce = nonce
         end
+        assert calldata_len = call_array[call_array_len-1].data_offset + call_array[call_array_len-1].data_len
         # TMP: Convert `AccountCallArray` to 'Call'.
         let (calls : Call*) = alloc()
         _from_call_array_to_call(call_array_len, call_array, calldata, calls)

--- a/contracts/account/library.cairo
+++ b/contracts/account/library.cairo
@@ -100,7 +100,7 @@ namespace Account:
             ecdsa_ptr : SignatureBuiltin*}(
             hash : felt, signature_len : felt, signature : felt*) -> ():
         let (_public_key) = Account_public_key.read()
-
+        assert signature_len = 2
         # This interface expects a signature pointer and length to make
         # no assumption about signature validation schemes.
         # But this implementation does, and it expects a (sig_r, sig_s) pair.
@@ -128,7 +128,6 @@ namespace Account:
         with_attr error_message("Account: nonce is invalid"):
             assert _current_nonce = nonce
         end
-
         # TMP: Convert `AccountCallArray` to 'Call'.
         let (calls : Call*) = alloc()
         _from_call_array_to_call(call_array_len, call_array, calldata, calls)


### PR DESCRIPTION
Using ToB's Amarna static analyzer (https://github.com/crytic/amarna), began to clean up our Cairo syntax with a priority on resolving warning flags. The unused arguments rule is important for detecting forgotten inputs, which is dangerous when the value was intended to run a check or modify the return value. (eg not gating an invalid signature bc you didn't use nonce to ```assert nonce = current_nonce```). 

I am uncertain about the fix's accuracy at line 131 for ```calldata_len``` because of the nature of finding the lengths of arrays which may have recursively appended structs in Cairo. Looking at the function definition for ```_from_call_array_to_call``` at lines 174-192,  my final index calls might have to be multiplied by Call.Size (or 4), depending on whether Cairo stores the sub array in an array of arrays, all at one index, or spreads each entry within the struct across four indices (which I think means I should have multiplied). 

Lastly, what do you think about putting with_attr error messages for these asserts, to be consistent with line 128, or is that too much syntactic sugar?

Also note, the unused argument ```aggregation mode``` at line 85 of ```contracts/oracle_implementation/library.cairo``` was ignored, and is intended to be patched with further logic in a subsequent release of the oracle implementation. 