### PR TITLE
Resolve Arth flags 

### DIFF
--- a/contracts/sample_consumer/CheckEthThreshold.cairo
+++ b/contracts/sample_consumer/CheckEthThreshold.cairo
@@ -19,7 +19,8 @@ func check_eth_usd_threshold{syscall_ptr : felt*, range_check_ptr}(threshold : f
 
     let (eth_price, timestamp) = IOracleController.get_value(
         ORACLE_CONTROLLER_ADDRESS, KEY, AGGREGATION_MODE)
-
+    #if you accidentally specificy a threshold in gwei and forget we already do the ETH to wei conversion internally, 
+    #shifted threshold could overflow. Not much of an issue, and reminds me to resolve create conversion helper function tickets
     let shifted_threshold = threshold * multiplier
     let (is_above_threshold) = is_le(shifted_threshold, eth_price)
     return (is_above_threshold)


### PR DESCRIPTION
Checked all the arithmetic flags (add, sub, mul). 

* All Pontis felt division is handled by starkware's unsigned_div_rem function, which checks for overflows. 
* Most ```expr_add``` flags are false positives marking pointer iteration, though I commented a few instances of over-flowable addition with a "who-passes-what-where" style for warnings.  TODO resolve further if needed
* Caught one risk of multiplicative overflow in the case of accidentally setting eth_threshold in gwei. See ticket in roadmap to make clearer with decorator. All other multiplication operations in pontis are struct size offsets to help with array construction or adding. Overflow risk is reduced when appending arrays because we periodically rewrite over our arrays.
* Subtraction errors are false positive; ie mostly standardizing a list to start counting from zero (preventing off-by-1 errors)